### PR TITLE
test: bring macos-13 example recordings back

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![MacOS Big Sur Support](https://img.shields.io/badge/macos-Big_Sur-blue.svg?logo=apple)](https://apps.apple.com/id/app/macos-big-sur/id1526878132)
 [![MacOS Monetary Support](https://img.shields.io/badge/macos-Monetary-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-monterey/id1576738294)
 [![MacOS Ventura Support](https://img.shields.io/badge/macos-Ventura-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-ventura/id1638787999)
+[![MacOS Sonoma Support](https://img.shields.io/badge/macos-Somona-blue.svg?logo=apple)](https://apps.apple.com/us/app/macos-sonoma/id6450717509)
 [![Windows 10 Support](https://img.shields.io/badge/windows-10-blue.svg?logo=windows10)](https://www.microsoft.com/en-gb/software-download/windows10ISO)
 [![Windows Server 2019 Support](https://img.shields.io/badge/windows_server-2019-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2019)
 [![Windows Server 2022 Support](https://img.shields.io/badge/windows_server-2022-blue.svg?logo=windows)](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2022)

--- a/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
@@ -30,12 +30,7 @@ test.describe("Chromium Playwright VoiceOver", () => {
     let stopRecording: (() => void) | undefined;
 
     try {
-      const isMacOSVentura =
-        osName === "darwin" && osVersion.split(".")[0] === "22";
-
-      if (!isMacOSVentura) {
-        stopRecording = macOSRecord(recordingFilePath);
-      }
+      stopRecording = macOSRecord(recordingFilePath);
 
       await headerNavigation({ page, voiceOver });
 

--- a/examples/playwright-voiceover/tests/chromium/chromium.spokenPhrase.snapshot.json
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spokenPhrase.snapshot.json
@@ -1,7 +1,7 @@
 [
-  "heading level 1 Guidepup",
+  "Guidepup heading level 1",
   "Screen Reader A11y Workflows",
-  "heading level 3 Full Control",
-  "heading level 3 Mirrors Real User Experience",
-  "heading level 3 Framework Agnostic"
+  "Full Control heading level 3",
+  "Mirrors Real User Experience heading level 3",
+  "Framework Agnostic heading level 3"
 ]

--- a/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
@@ -30,12 +30,7 @@ test.describe("Firefox Playwright VoiceOver", () => {
     let stopRecording: (() => void) | undefined;
 
     try {
-      const isMacOSVentura =
-        osName === "darwin" && osVersion.split(".")[0] === "22";
-
-      if (!isMacOSVentura) {
-        stopRecording = macOSRecord(recordingFilePath);
-      }
+      stopRecording = macOSRecord(recordingFilePath);
 
       await headerNavigation({ page, voiceOver });
 

--- a/examples/playwright-voiceover/tests/firefox/firefox.spokenPhrase.snapshot.json
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spokenPhrase.snapshot.json
@@ -1,7 +1,7 @@
 [
-  "heading level 1 Guidepup",
+  "Guidepup heading level 1",
   "Screen Reader A11y Workflows",
-  "heading level 3 Full Control",
-  "heading level 3 Mirrors Real User Experience",
-  "heading level 3 Framework Agnostic"
+  "Full Control heading level 3",
+  "Mirrors Real User Experience heading level 3",
+  "Framework Agnostic heading level 3"
 ]

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -30,12 +30,7 @@ test.describe("Webkit Playwright VoiceOver", () => {
     let stopRecording: (() => void) | undefined;
 
     try {
-      const isMacOSVentura =
-        osName === "darwin" && osVersion.split(".")[0] === "22";
-
-      if (!isMacOSVentura) {
-        stopRecording = macOSRecord(recordingFilePath);
-      }
+      stopRecording = macOSRecord(recordingFilePath);
 
       await headerNavigation({ page, voiceOver });
 

--- a/examples/playwright-voiceover/tests/webkit/webkit.spokenPhrase.snapshot.json
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spokenPhrase.snapshot.json
@@ -1,7 +1,7 @@
 [
-  "heading level 1 Guidepup",
+  "Guidepup heading level 1",
   "Screen Reader A11y Workflows",
-  "heading level 3 Full Control",
-  "heading level 3 Mirrors Real User Experience",
-  "heading level 3 Framework Agnostic"
+  "Full Control heading level 3",
+  "Mirrors Real User Experience heading level 3",
+  "Framework Agnostic heading level 3"
 ]

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:voiceover:webkit": "playwright test --config ./examples/playwright-voiceover/webkit.config.ts ./examples/playwright-voiceover/tests/webkit/"
   },
   "devDependencies": {
-    "@guidepup/guidepup": "^0.22.0",
+    "@guidepup/guidepup": "^0.22.1",
     "@playwright/test": "^1.41.1",
     "@types/node": "^20.11.15",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -52,7 +52,7 @@
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
-    "@guidepup/guidepup": "^0.22.0",
+    "@guidepup/guidepup": "^0.22.1",
     "@playwright/test": "^1.40.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,10 +56,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.56.0.tgz#ef20350fec605a7f7035a01764731b2de0f3782b"
   integrity sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==
 
-"@guidepup/guidepup@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@guidepup/guidepup/-/guidepup-0.22.0.tgz#f3fc757c1f40dcf8920027c5dfeff2486a589686"
-  integrity sha512-AOXe7WaFdeY3Dwr/CKrq0aS6TAor9Jq8nz550i740z9yD3DqpJkEW4hYoU5HinbsMNGK2Iqzv5AcFfJixEiPoQ==
+"@guidepup/guidepup@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@guidepup/guidepup/-/guidepup-0.22.1.tgz#05a43570fc6bd987c24b3c3103158725a2e77a70"
+  integrity sha512-vf2uH+l6TAWBANGg4bQXommwFDnY4XoqPbuqDi338vBPiqoXLqkLAP0kOt4SBL76NEHbO8Gz2y8xtlm29hS6/Q==
   dependencies:
     ffmpeg-static "^5.2.0"
     regedit "5.1.2"


### PR DESCRIPTION
## Details

GitHub actions runner images have released changes to permissions for recording, should be able to bring the recording functionality back for macos-13

## CheckList

- [ ] Has been tested (where required).
