### PR TITLE
feat: allow setting of start options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 lib
 .DS_Store
 test-results
+recordings

--- a/README.md
+++ b/README.md
@@ -110,10 +110,28 @@ await nvda.navigateToWebContent();
 
 // ... some commands
 
-// Collect all spoken phrasees
+// Collect all spoken phrases
 const allSpokenPhrases = [...spokenPhrases, ...(await nvda.spokenPhraseLog())];
 
 // ... do something with spoken phrases
+```
+
+### Providing Screen Reader Start Options
+
+The options provided to `nvda.start([options])` or `voiceOver.start([options])` can be configured using `test.use(config)` as follows:
+
+```ts
+// VoiceOver Example
+import { voiceOverTest as test } from "@guidepup/playwright";
+
+test.use({ voiceOverStartOptions: { capture: "initial" } });
+```
+
+```ts
+// NVDA Example
+import { nvdaTest as test } from "@guidepup/playwright";
+
+test.use({ nvdaStartOptions: { capture: "initial" } });
 ```
 
 ### VoiceOver Example

--- a/examples/playwright-nvda/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-nvda/tests/chromium/chromium.spec.ts
@@ -5,6 +5,8 @@ import { windowsRecord } from "@guidepup/guidepup";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
 import { nvdaTest as test } from "../../../../src";
 
+test.use({ nvdaStartOptions: { capture: "initial" } });
+
 test.describe("Chromium Playwright NVDA", () => {
   test("I can navigate the Guidepup Github page", async ({
     browser,

--- a/examples/playwright-nvda/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-nvda/tests/firefox/firefox.spec.ts
@@ -5,6 +5,8 @@ import { windowsRecord } from "@guidepup/guidepup";
 import spokenPhraseSnapshot from "./firefox.spokenPhrase.snapshot.json";
 import { nvdaTest as test } from "../../../../src";
 
+test.use({ nvdaStartOptions: { capture: "initial" } });
+
 test.describe("Firefox Playwright VoiceOver", () => {
   test("I can navigate the Guidepup Github page", async ({
     browser,

--- a/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
+++ b/examples/playwright-voiceover/tests/chromium/chromium.spec.ts
@@ -6,6 +6,8 @@ import { macOSRecord } from "@guidepup/guidepup";
 import spokenPhraseSnapshot from "./chromium.spokenPhrase.snapshot.json";
 import { voiceOverTest as test } from "../../../../src";
 
+test.use({ voiceOverStartOptions: { capture: "initial" } });
+
 test.describe("Chromium Playwright VoiceOver", () => {
   test("I can navigate the Guidepup Github page", async ({
     browser,

--- a/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
+++ b/examples/playwright-voiceover/tests/firefox/firefox.spec.ts
@@ -6,6 +6,8 @@ import { macOSRecord } from "@guidepup/guidepup";
 import spokenPhraseSnapshot from "./firefox.spokenPhrase.snapshot.json";
 import { voiceOverTest as test } from "../../../../src";
 
+test.use({ voiceOverStartOptions: { capture: "initial" } });
+
 test.describe("Firefox Playwright VoiceOver", () => {
   test("I can navigate the Guidepup Github page", async ({
     browser,

--- a/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
+++ b/examples/playwright-voiceover/tests/webkit/webkit.spec.ts
@@ -6,6 +6,8 @@ import { macOSRecord } from "@guidepup/guidepup";
 import spokenPhraseSnapshot from "./webkit.spokenPhrase.snapshot.json";
 import { voiceOverTest as test } from "../../../../src";
 
+test.use({ voiceOverStartOptions: { capture: "initial" } });
+
 test.describe("Webkit Playwright VoiceOver", () => {
   test("I can navigate the Guidepup Github page", async ({
     browser,

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -122,6 +122,7 @@ export const nvdaTest = test.extend<{
    */
   nvdaStartOptions: CaptureCommandOptions;
 }>({
+  nvdaStartOptions: {},
   nvda: async ({ browserName, page, nvdaStartOptions }, use) => {
     try {
       const applicationName = applicationNameMap[browserName];

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -1,7 +1,14 @@
 import { test } from "@playwright/test";
 import { nvda, WindowsKeyCodes, WindowsModifiers } from "@guidepup/guidepup";
-import type { NVDA } from "@guidepup/guidepup";
+import type { CommandOptions, NVDA } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
+
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};
+
+type CaptureCommandOptions = Prettify<Pick<CommandOptions, "capture">>;
 
 /**
  * [API Reference](https://www.guidepup.dev/docs/api/class-nvda)
@@ -108,8 +115,14 @@ export const nvdaTest = test.extend<{
    * ```
    */
   nvda: NVDAPlaywright;
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-command-options)
+   *
+   * Options to start NVDA with, see also [nvda.start([options])](https://www.guidepup.dev/docs/api/class-nvda#nvda-start).
+   */
+  nvdaStartOptions: CaptureCommandOptions;
 }>({
-  nvda: async ({ browserName, page }, use) => {
+  nvda: async ({ browserName, page, nvdaStartOptions }, use) => {
     try {
       const applicationName = applicationNameMap[browserName];
 
@@ -158,7 +171,7 @@ export const nvdaTest = test.extend<{
         await nvdaPlaywright.clearSpokenPhraseLog();
       };
 
-      await nvdaPlaywright.start();
+      await nvdaPlaywright.start(nvdaStartOptions);
 
       await use(nvdaPlaywright);
     } finally {

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test";
 import { voiceOver, macOSActivate } from "@guidepup/guidepup";
-import type { VoiceOver } from "@guidepup/guidepup";
+import type { CommandOptions, VoiceOver } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
 
 /**
@@ -74,8 +74,15 @@ export const voiceOverTest = test.extend<{
    * ```
    */
   voiceOver: VoiceOverPlaywright;
+  /**
+   * [API Reference](https://www.guidepup.dev/docs/api/class-command-options)
+   *
+   * Options to start VoiceOver with, see also [voiceOver.start([options])](https://www.guidepup.dev/docs/api/class-voiceover#voiceover-start).
+   */
+  voiceOverStartOptions: CommandOptions;
 }>({
-  voiceOver: async ({ browserName, page }, use) => {
+  voiceOverStartOptions: {},
+  voiceOver: async ({ browserName, page, voiceOverStartOptions }, use) => {
     try {
       const applicationName = applicationNameMap[browserName];
 
@@ -103,7 +110,7 @@ export const voiceOverTest = test.extend<{
         await voiceOverPlaywright.clearSpokenPhraseLog();
       };
 
-      await voiceOverPlaywright.start();
+      await voiceOverPlaywright.start(voiceOverStartOptions);
       await macOSActivate(applicationName);
       await use(voiceOverPlaywright);
     } finally {


### PR DESCRIPTION
# Issue

No issue.

## Details

Currently there is no way to configure the start options for screen readers that are started automatically by this package.

If you want to instead set the `capture` start option to be `"initial"` you currently need to stop and restart the screen reader.

This change introduces new options that work with the exported `test*.use()` to allow this config to be set.

## CheckList

- [ ] Has been tested (where required).
