### PR TITLE
refactor: updating GH action

### DIFF
--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn pretest
       - run: yarn test:voiceover:${{ matrix.browser }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:


### PR DESCRIPTION
# Issue

~Fixes #<issue_number>.~

## Details

Prevent the pipeline throwing an error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## CheckList

- [ ] ~Has been tested (where required).~
