### PR TITLE
refactor: updating GH actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,5 +67,5 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       continue-on-error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
           always-auth: true
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.17.2
         with:

--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -14,7 +14,7 @@ jobs:
         os: [windows-2019, windows-2022]
         browser: [chromium, firefox]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         browser: [chromium, firefox]
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.17.2
+        uses: guidepup/setup-action@0.17.3
         with:
           record: true
       - run: yarn install --frozen-lockfile
@@ -29,7 +29,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-${{ matrix.browser }}
           path: |
             **/test-results/**/*
             **/recordings/**/*

--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn pretest
       - run: yarn test:nvda:${{ matrix.browser }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -15,7 +15,7 @@ jobs:
         browser: [chromium, firefox]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Guidepup Setup

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.17.2
+        uses: guidepup/setup-action@0.17.3
         with:
           record: true
       - run: yarn install --frozen-lockfile
@@ -29,7 +29,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          name: artifacts
+          name: artifacts-${{ matrix.os }}-${{ matrix.browser }}
           path: |
             **/test-results/**/*
             **/recordings/**/*

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - name: Guidepup Setup
         uses: guidepup/setup-action@0.17.2
         with:

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn pretest
       - run: yarn test:voiceover:${{ matrix.browser }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         continue-on-error: true
         with:

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -15,7 +15,7 @@ jobs:
         browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Guidepup Setup

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -14,7 +14,7 @@ jobs:
         os: [macos-12, macos-13, macos-14]
         browser: [chromium, firefox, webkit]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
       - run: yarn install --frozen-lockfile
       - run: yarn ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
# Issue

~Fixes #<issue_number>.~

## Details

Prevent the pipeline throwing an error:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

in general updated the following standard actions:
- [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v4.0.0)
  - ✅ update to node 20
- [actions/checkout](https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400)
  - ✅ update to node 20
- [actions/upload-artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
  - ⚠️ [Multiple uploads to the same named Artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)
  - [Overwriting an Artifact](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact)
  - [Merging multiple artifacts](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#merging-multiple-artifacts)
  - [Hidden files](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#hidden-files)

Plus we could target for the node version defined in `.nvmrc` directly.

## CheckList

- [ ] ~Has been tested (where required).~
