### PR TITLE
fix: support new name for Chromium

### DIFF
--- a/.github/workflows/test-nvda.yml
+++ b/.github/workflows/test-nvda.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.18.0
+        uses: guidepup/setup-action@0.19.0
         with:
           record: true
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Guidepup Setup
-        uses: guidepup/setup-action@0.18.0
+        uses: guidepup/setup-action@0.19.0
         with:
           record: true
       - run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guidepup/playwright",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "description": "Screen reader driver for Playwright tests.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@guidepup/guidepup": "^0.24.0",
     "@guidepup/record": "^0.1.0",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.58.0",
     "@types/node": "^24.10.1",
     "@typescript-eslint/eslint-plugin": "^8.48.1",
     "@typescript-eslint/parser": "^8.48.1",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@guidepup/guidepup": ">=0.22.1",
-    "@playwright/test": "^1.40.1"
+    "@playwright/test": "^1.57.0"
   },
   "resolutions": {
     "strip-ansi": "6.0.1",

--- a/src/applicationNameMap.ts
+++ b/src/applicationNameMap.ts
@@ -1,5 +1,5 @@
 export const applicationNameMap = {
-  chromium: "Chromium",
+  chromium: "Google Chrome For Testing",
   chrome: "Google Chrome",
   "chrome-beta": "Google Chrome Beta",
   msedge: "Microsoft Edge",

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,12 +155,12 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/test@^1.57.0":
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.57.0.tgz#a14720ffa9ed7ef7edbc1f60784fc6134acbb003"
-  integrity sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==
+"@playwright/test@^1.58.0":
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.58.0.tgz#7e768ebaadd4db5531fee812d876a0641f4fa10a"
+  integrity sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==
   dependencies:
-    playwright "1.57.0"
+    playwright "1.58.0"
 
 "@shikijs/engine-oniguruma@^3.19.0":
   version "3.19.0"
@@ -1087,17 +1087,17 @@ picomatch@^4.0.3:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
-playwright-core@1.57.0:
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.57.0.tgz#3dcc9a865af256fa9f0af0d67fc8dd54eecaebf5"
-  integrity sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==
+playwright-core@1.58.0:
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.58.0.tgz#f0c74217837e5dda1ecfae78e214fe97112c1f97"
+  integrity sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==
 
-playwright@1.57.0:
-  version "1.57.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.57.0.tgz#74d1dacff5048dc40bf4676940b1901e18ad0f46"
-  integrity sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==
+playwright@1.58.0:
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.58.0.tgz#f0a0d9b6b93d153338951ac7fb9dd8d0ea256e53"
+  integrity sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==
   dependencies:
-    playwright-core "1.57.0"
+    playwright-core "1.58.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
# Issue

No issue.

## Details

Updates the application name for "Chromium" to "Google Chrome For Testing" following Playwright 1.57.0 update.

Stopgap while evaluate other options such as #32 to move away from coupling to vendor specific names which makes this logic fragile to Playwright changing their implementation.

## CheckList

- [ ] Has been tested (where required).
