### PR TITLE
fix: prevent auto-navigation of web content

### DIFF
--- a/.github/workflows/test-voiceover.yml
+++ b/.github/workflows/test-voiceover.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
+        os: [macos-14, macos-15, macos-26]
         browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@v6

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -102,27 +102,21 @@ export const voiceOverTest = test.extend<{
         // Ensure the document is ready and focused.
         await page.bringToFront();
         await page.locator("body").waitFor();
-        await page.locator("body").focus();
-        await page.locator("body").click();
-        await page.locator("body").blur();
 
-        // Try to navigate into web content.
+        // Open the web item rotor defaulting to window spots.
+        await voiceOverPlaywright.perform(
+          voiceOverPlaywright.keyboardCommands.openWebItemRotor,
+        );
+
+        // Filter by "content" - currently web content spots for all browsers
+        // are prefixed by "Content -".
+        await voiceOverPlaywright.type("content");
+
+        // Select the web content window spot.
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Enter });
+
+        // Navigate into web content.
         await voiceOverPlaywright.interact();
-
-        // Cancel auto navigation
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
-
-        // Series of find previous commands to escape accidental interaction
-        // with sub-content of web content area.
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.findPreviousHeading,
-        );
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.findPreviousGraphic,
-        );
-        await voiceOverPlaywright.perform(
-          voiceOverPlaywright.keyboardCommands.findPreviousPlainText,
-        );
 
         // Navigate to the beginning of the web content.
         await voiceOverPlaywright.perform(

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import { voiceOver, macOSActivate } from "@guidepup/guidepup";
+import { voiceOver, macOSActivate, MacOSKeyCodes } from "@guidepup/guidepup";
 import type { CommandOptions, VoiceOver } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
 
@@ -96,6 +96,9 @@ export const voiceOverTest = test.extend<{
         // Ensure application is brought to front and focused.
         await macOSActivate(applicationName);
 
+        // Cancel auto navigation
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+
         // Ensure the document is ready and focused.
         await page.bringToFront();
         await page.locator("body").waitFor();
@@ -105,6 +108,9 @@ export const voiceOverTest = test.extend<{
 
         // Try to navigate into web content.
         await voiceOverPlaywright.interact();
+
+        // Cancel auto navigation
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
 
         // Series of find previous commands to escape accidental interaction
         // with sub-content of web content area.
@@ -123,6 +129,9 @@ export const voiceOverTest = test.extend<{
           voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
         );
 
+        // Cancel auto navigation
+        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+
         if (clearLogs) {
           // Clear out logs.
           await voiceOverPlaywright.clearItemTextLog();
@@ -132,6 +141,13 @@ export const voiceOverTest = test.extend<{
 
       await voiceOverPlaywright.start(voiceOverStartOptions);
       await macOSActivate(applicationName);
+
+      // Cancel auto navigation
+      await voiceOverPlaywright.perform(
+        { keyCode: MacOSKeyCodes.Control },
+        { capture: false },
+      );
+
       await use(voiceOverPlaywright);
     } finally {
       try {


### PR DESCRIPTION
# Issue

Fixes #36 

## Details

At key points in VO fixture startup, and during navigation to web content, attempt to stop the default auto-navigation of web content (particularly prolific in Firefox as other command executions don't appear to stop it).

## CheckList

- [ ] Has been tested (where required).
