### PR TITLE
feat!: treat `navigateToWebContent` same as other guidepup methods

### DIFF
--- a/examples/playwright-nvda/tests/headerNavigation.ts
+++ b/examples/playwright-nvda/tests/headerNavigation.ts
@@ -1,10 +1,7 @@
 import { Page } from "@playwright/test";
 import { log } from "../../log";
 import type { NVDAPlaywright } from "../../../src";
-
-async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { delay } from "../../../src/delay";
 
 const MAX_NAVIGATION_LOOP = 10;
 

--- a/examples/playwright-screenreader/tests/headerNavigation.ts
+++ b/examples/playwright-screenreader/tests/headerNavigation.ts
@@ -1,12 +1,9 @@
 import { log } from "../../log";
 import { Page } from "@playwright/test";
 import type { ScreenReaderPlaywright } from "../../../src";
+import { delay } from "../../../src/delay";
 
 const MAX_NAVIGATION_LOOP = 10;
-
-export async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 export async function headerNavigation({
   page,

--- a/examples/playwright-voiceover/tests/headerNavigation.ts
+++ b/examples/playwright-voiceover/tests/headerNavigation.ts
@@ -1,10 +1,7 @@
 import { Page } from "@playwright/test";
 import { log } from "../../log";
 import type { VoiceOverPlaywright } from "../../../src";
-
-async function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
+import { delay } from "../../../src/delay";
 
 const MAX_NAVIGATION_LOOP = 10;
 
@@ -47,7 +44,7 @@ export async function headerNavigation({
     // Describe the item in the VoiceOver cursor as it can sometimes skip part
     // of the spoken phrase if interrupted.
     log(
-      `Performing command: "VO+F3" - "Describe the item in the VoiceOver cursor"`
+      `Performing command: "VO+F3" - "Describe the item in the VoiceOver cursor"`,
     );
     await voiceOver.perform(voiceOver.keyboardCommands.describeItem);
     log(`Screen reader output: "${await voiceOver.lastSpokenPhrase()}".`);

--- a/src/delay.ts
+++ b/src/delay.ts
@@ -1,0 +1,3 @@
+export async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -160,7 +160,7 @@ export const nvdaTest = test.extend<{
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      nvdaPlaywright.navigateToWebContent = async ({ capture }) => {
+      nvdaPlaywright.navigateToWebContent = async ({ capture } = {}) => {
         const currentSpokenPhraseLog = [
           ...(await nvdaPlaywright.spokenPhraseLog()),
         ];

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -37,10 +37,8 @@ export interface NVDAPlaywright extends NVDA {
    * of the browser's web content.
    *
    * This command should be used after page navigation.
-   *
-   * Note: this command clears all logs by default.
    */
-  navigateToWebContent(clearLogs?: boolean): Promise<void>;
+  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
 }
 
 const nvdaPlaywright: NVDAPlaywright = nvda as NVDAPlaywright;
@@ -105,7 +103,8 @@ const focusBrowser = async ({
   while (applicationSwitchRetryCount < MAX_APPLICATION_SWITCH_RETRY_COUNT) {
     applicationSwitchRetryCount++;
 
-    await nvdaPlaywright.perform(SWITCH_APPLICATION);
+    await nvdaPlaywright.perform(SWITCH_APPLICATION, { capture: false });
+
     await nvdaPlaywright.perform(nvdaPlaywright.keyboardCommands.reportTitle);
     windowTitle = await nvdaPlaywright.lastSpokenPhrase();
 
@@ -161,20 +160,21 @@ export const nvdaTest = test.extend<{
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      nvdaPlaywright.navigateToWebContent = async (
-        clearLogs: boolean = true,
-      ) => {
+      nvdaPlaywright.navigateToWebContent = async ({ capture }) => {
+        const currentSpokenPhraseLog = [
+          ...(await nvdaPlaywright.spokenPhraseLog()),
+        ];
+        const currentItemTextLog = [...(await nvdaPlaywright.itemTextLog())];
+
         // Make sure NVDA is not in focus mode.
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.exitFocusMode,
+          { capture: false },
         );
 
-        const pageTitle = await page.title();
         // Ensure application is brought to front and focused.
-        await focusBrowser({
-          applicationName,
-          pageTitle,
-        });
+        const pageTitle = await page.title();
+        await focusBrowser({ applicationName, pageTitle });
 
         // Ensure the document is ready and focused.
         await page.bringToFront();
@@ -195,23 +195,33 @@ export const nvdaTest = test.extend<{
         // REF: https://github.com/nvaccess/nvda/issues/5758
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.readNextFocusableItem,
+          { capture: false },
         );
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
+          { capture: false },
         );
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
+          { capture: false },
         );
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.exitFocusMode,
+          { capture: false },
         );
-        await nvdaPlaywright.perform(MOVE_TO_TOP);
 
-        if (clearLogs) {
-          // Clear out logs.
-          await nvdaPlaywright.clearItemTextLog();
-          await nvdaPlaywright.clearSpokenPhraseLog();
-        }
+        await nvdaPlaywright.clearSpokenPhraseLog();
+        await nvdaPlaywright.clearItemTextLog();
+
+        const spokenPhraseLog = await nvdaPlaywright.spokenPhraseLog();
+        const itemTextLog = await nvdaPlaywright.itemTextLog();
+
+        spokenPhraseLog.push(...currentSpokenPhraseLog);
+        itemTextLog.push(...currentItemTextLog);
+
+        // Navigate to the beginning of the web content, using chosen capture
+        // settings, so don't miss announcing the first item on the page.
+        await nvdaPlaywright.perform(MOVE_TO_TOP, { capture });
       };
 
       await nvdaPlaywright.start(nvdaStartOptions);

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -2,6 +2,7 @@ import { test } from "@playwright/test";
 import { nvda, WindowsKeyCodes, WindowsModifiers } from "@guidepup/guidepup";
 import type { CommandOptions, NVDA } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
+import { delay } from "./delay";
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -38,7 +39,9 @@ export interface NVDAPlaywright extends NVDA {
    *
    * This command should be used after page navigation.
    */
-  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
+  navigateToWebContent(
+    options?: Pick<CommandOptions, "capture">,
+  ): Promise<void>;
 }
 
 const nvdaPlaywright: NVDAPlaywright = nvda as NVDAPlaywright;
@@ -104,6 +107,7 @@ const focusBrowser = async ({
     applicationSwitchRetryCount++;
 
     await nvdaPlaywright.perform(SWITCH_APPLICATION, { capture: false });
+    await delay(100);
 
     await nvdaPlaywright.perform(nvdaPlaywright.keyboardCommands.reportTitle);
     windowTitle = await nvdaPlaywright.lastSpokenPhrase();
@@ -171,6 +175,7 @@ export const nvdaTest = test.extend<{
           nvdaPlaywright.keyboardCommands.exitFocusMode,
           { capture: false },
         );
+        await delay(100);
 
         // Ensure application is brought to front and focused.
         const pageTitle = await page.title();
@@ -197,18 +202,22 @@ export const nvdaTest = test.extend<{
           nvdaPlaywright.keyboardCommands.readNextFocusableItem,
           { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
           { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.toggleBetweenBrowseAndFocusMode,
           { capture: false },
         );
+        await delay(100);
         await nvdaPlaywright.perform(
           nvdaPlaywright.keyboardCommands.exitFocusMode,
           { capture: false },
         );
+        await delay(100);
 
         await nvdaPlaywright.clearSpokenPhraseLog();
         await nvdaPlaywright.clearItemTextLog();

--- a/src/nvdaTest.ts
+++ b/src/nvdaTest.ts
@@ -107,7 +107,7 @@ const focusBrowser = async ({
     applicationSwitchRetryCount++;
 
     await nvdaPlaywright.perform(SWITCH_APPLICATION, { capture: false });
-    await delay(100);
+    await delay(500);
 
     await nvdaPlaywright.perform(nvdaPlaywright.keyboardCommands.reportTitle);
     windowTitle = await nvdaPlaywright.lastSpokenPhrase();

--- a/src/screenReaderTest.ts
+++ b/src/screenReaderTest.ts
@@ -13,6 +13,7 @@ import {
   WindowsModifiers,
 } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
+import { delay } from "./delay";
 
 type Prettify<T> = {
   [K in keyof T]: T[K];
@@ -83,6 +84,7 @@ const focusBrowser = async ({
     await screenReaderPlaywright.perform(SWITCH_APPLICATION, {
       capture: false,
     });
+    await delay(100);
 
     await screenReaderPlaywright.perform(NVDAKeyCodeCommands.reportTitle);
     windowTitle = await screenReaderPlaywright.lastSpokenPhrase();
@@ -123,7 +125,9 @@ export interface ScreenReaderPlaywright extends ScreenReader {
    *
    * This command should be used after page navigation.
    */
-  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
+  navigateToWebContent(
+    options?: Pick<CommandOptions, "capture">,
+  ): Promise<void>;
 }
 
 const screenReaderPlaywright: ScreenReaderPlaywright =
@@ -195,6 +199,7 @@ export const screenReaderTest = test.extend<{
             NVDAKeyCodeCommands.exitFocusMode,
             { capture: false },
           );
+          await delay(100);
 
           // Ensure application is brought to front and focused.
           const pageTitle = await page.title();
@@ -221,18 +226,22 @@ export const screenReaderTest = test.extend<{
             NVDAKeyCodeCommands.readNextFocusableItem,
             { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
             { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
             { capture: false },
           );
+          await delay(100);
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.exitFocusMode,
             { capture: false },
           );
+          await delay(100);
 
           await screenReaderPlaywright.clearSpokenPhraseLog();
           await screenReaderPlaywright.clearItemTextLog();
@@ -252,39 +261,58 @@ export const screenReaderTest = test.extend<{
         screenReaderPlaywright.navigateToWebContent = async ({
           capture,
         } = {}) => {
+          // Ensure application is brought to front and focused.
           await macOSActivate(applicationName);
 
+          // Cancel auto navigation.
           await screenReaderPlaywright.perform(
             { keyCode: MacOSKeyCodes.Control },
             { capture: false },
           );
+          await delay(100);
 
+          // Ensure the document is ready and focused.
           await page.bringToFront();
           await page.locator("body").waitFor();
 
+          // Open the web item chooser.
           await screenReaderPlaywright.perform(
             voiceOverKeyCodeCommands.openItemChooser,
             { capture: false },
           );
+          await delay(100);
 
-          await screenReaderPlaywright.type("web content", { capture: false });
+          // Filter by "web content" - currently web content items for all browsers
+          // are suffixed by "web content".
+          for (const character of "web content") {
+            await screenReaderPlaywright.type(character, { capture: false });
+            await delay(100);
+          }
 
+          // Select the web content window spot.
           await screenReaderPlaywright.perform(
             { keyCode: MacOSKeyCodes.Enter },
             { capture: false },
           );
+          await delay(100);
 
+          // Navigate into web content.
           await screenReaderPlaywright.interact({ capture: false });
+          await delay(100);
 
+          // Navigate to the beginning of the web content.
           await screenReaderPlaywright.perform(
             voiceOverKeyCodeCommands.moveToBeginningOfText,
             { capture: false },
           );
+          await delay(100);
 
+          // Cancel auto navigation
           await screenReaderPlaywright.perform(
             { keyCode: MacOSKeyCodes.Control },
             { capture: false },
           );
+          await delay(100);
 
           // Navigate to the beginning of the web content, using chosen capture
           // settings, so don't miss announcing the first item on the page.

--- a/src/screenReaderTest.ts
+++ b/src/screenReaderTest.ts
@@ -180,7 +180,9 @@ export const screenReaderTest = test.extend<{
       }
 
       if (nvda.default()) {
-        screenReaderPlaywright.navigateToWebContent = async ({ capture }) => {
+        screenReaderPlaywright.navigateToWebContent = async ({
+          capture,
+        } = {}) => {
           const currentSpokenPhraseLog = [
             ...(await screenReaderPlaywright.spokenPhraseLog()),
           ];
@@ -247,7 +249,9 @@ export const screenReaderTest = test.extend<{
           await screenReaderPlaywright.perform(MOVE_TO_TOP, { capture });
         };
       } else if (voiceOver.default()) {
-        screenReaderPlaywright.navigateToWebContent = async ({ capture }) => {
+        screenReaderPlaywright.navigateToWebContent = async ({
+          capture,
+        } = {}) => {
           await macOSActivate(applicationName);
 
           await screenReaderPlaywright.perform(

--- a/src/screenReaderTest.ts
+++ b/src/screenReaderTest.ts
@@ -80,7 +80,10 @@ const focusBrowser = async ({
   while (applicationSwitchRetryCount < MAX_APPLICATION_SWITCH_RETRY_COUNT) {
     applicationSwitchRetryCount++;
 
-    await screenReaderPlaywright.perform(SWITCH_APPLICATION);
+    await screenReaderPlaywright.perform(SWITCH_APPLICATION, {
+      capture: false,
+    });
+
     await screenReaderPlaywright.perform(NVDAKeyCodeCommands.reportTitle);
     windowTitle = await screenReaderPlaywright.lastSpokenPhrase();
 
@@ -119,10 +122,8 @@ export interface ScreenReaderPlaywright extends ScreenReader {
    * the beginning of the browser's web content.
    *
    * This command should be used after page navigation.
-   *
-   * Note: this command clears all logs by default.
    */
-  navigateToWebContent(clearLogs?: boolean): Promise<void>;
+  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
 }
 
 const screenReaderPlaywright: ScreenReaderPlaywright =
@@ -179,16 +180,22 @@ export const screenReaderTest = test.extend<{
       }
 
       if (nvda.default()) {
-        screenReaderPlaywright.navigateToWebContent = async (
-          clearLogs: boolean = true,
-        ) => {
+        screenReaderPlaywright.navigateToWebContent = async ({ capture }) => {
+          const currentSpokenPhraseLog = [
+            ...(await screenReaderPlaywright.spokenPhraseLog()),
+          ];
+          const currentItemTextLog = [
+            ...(await screenReaderPlaywright.itemTextLog()),
+          ];
+
           // Make sure NVDA is not in focus mode.
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.exitFocusMode,
+            { capture: false },
           );
 
-          const pageTitle = await page.title();
           // Ensure application is brought to front and focused.
+          const pageTitle = await page.title();
           await focusBrowser({ applicationName, pageTitle });
 
           // Ensure the document is ready and focused.
@@ -210,61 +217,77 @@ export const screenReaderTest = test.extend<{
           // REF: https://github.com/nvaccess/nvda/issues/5758
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.readNextFocusableItem,
+            { capture: false },
           );
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
+            { capture: false },
           );
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.toggleBetweenBrowseAndFocusMode,
+            { capture: false },
           );
           await screenReaderPlaywright.perform(
             NVDAKeyCodeCommands.exitFocusMode,
+            { capture: false },
           );
-          await screenReaderPlaywright.perform(MOVE_TO_TOP);
 
-          if (clearLogs) {
-            // Clear out logs.
-            await screenReaderPlaywright.clearItemTextLog();
-            await screenReaderPlaywright.clearSpokenPhraseLog();
-          }
+          await screenReaderPlaywright.clearSpokenPhraseLog();
+          await screenReaderPlaywright.clearItemTextLog();
+
+          const spokenPhraseLog =
+            await screenReaderPlaywright.spokenPhraseLog();
+          const itemTextLog = await screenReaderPlaywright.itemTextLog();
+
+          spokenPhraseLog.push(...currentSpokenPhraseLog);
+          itemTextLog.push(...currentItemTextLog);
+
+          // Navigate to the beginning of the web content, using chosen capture
+          // settings, so don't miss announcing the first item on the page.
+          await screenReaderPlaywright.perform(MOVE_TO_TOP, { capture });
         };
       } else if (voiceOver.default()) {
-        screenReaderPlaywright.navigateToWebContent = async (
-          clearLogs: boolean = true,
-        ) => {
+        screenReaderPlaywright.navigateToWebContent = async ({ capture }) => {
           await macOSActivate(applicationName);
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Control,
-          });
+          await screenReaderPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Control },
+            { capture: false },
+          );
 
           await page.bringToFront();
           await page.locator("body").waitFor();
 
           await screenReaderPlaywright.perform(
             voiceOverKeyCodeCommands.openItemChooser,
+            { capture: false },
           );
 
-          await screenReaderPlaywright.type("web content");
+          await screenReaderPlaywright.type("web content", { capture: false });
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Enter,
-          });
+          await screenReaderPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Enter },
+            { capture: false },
+          );
 
-          await screenReaderPlaywright.interact();
+          await screenReaderPlaywright.interact({ capture: false });
 
           await screenReaderPlaywright.perform(
             voiceOverKeyCodeCommands.moveToBeginningOfText,
+            { capture: false },
           );
 
-          await screenReaderPlaywright.perform({
-            keyCode: MacOSKeyCodes.Control,
-          });
+          await screenReaderPlaywright.perform(
+            { keyCode: MacOSKeyCodes.Control },
+            { capture: false },
+          );
 
-          if (clearLogs) {
-            await screenReaderPlaywright.clearItemTextLog();
-            await screenReaderPlaywright.clearSpokenPhraseLog();
-          }
+          // Navigate to the beginning of the web content, using chosen capture
+          // settings, so don't miss announcing the first item on the page.
+          await screenReaderPlaywright.perform(
+            voiceOverKeyCodeCommands.moveToBeginningOfText,
+            { capture },
+          );
         };
       } else {
         throw new Error("No supported screen reader");

--- a/src/screenReaderTest.ts
+++ b/src/screenReaderTest.ts
@@ -84,7 +84,7 @@ const focusBrowser = async ({
     await screenReaderPlaywright.perform(SWITCH_APPLICATION, {
       capture: false,
     });
-    await delay(100);
+    await delay(500);
 
     await screenReaderPlaywright.perform(NVDAKeyCodeCommands.reportTitle);
     windowTitle = await screenReaderPlaywright.lastSpokenPhrase();
@@ -280,7 +280,7 @@ export const screenReaderTest = test.extend<{
             voiceOverKeyCodeCommands.openItemChooser,
             { capture: false },
           );
-          await delay(100);
+          await delay(500);
 
           // Filter by "web content" - currently web content items for all browsers
           // are suffixed by "web content".

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -2,6 +2,7 @@ import { test } from "@playwright/test";
 import { voiceOver, macOSActivate, MacOSKeyCodes } from "@guidepup/guidepup";
 import type { CommandOptions, VoiceOver } from "@guidepup/guidepup";
 import { applicationNameMap } from "./applicationNameMap";
+import { delay } from "./delay";
 
 /**
  * [API Reference](https://www.guidepup.dev/docs/api/class-voiceover)
@@ -34,7 +35,9 @@ export interface VoiceOverPlaywright extends VoiceOver {
    *
    * This command should be used after a page navigation has completed.
    */
-  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
+  navigateToWebContent(
+    options?: Pick<CommandOptions, "capture">,
+  ): Promise<void>;
 }
 
 const voiceOverPlaywright: VoiceOverPlaywright =
@@ -92,11 +95,12 @@ export const voiceOverTest = test.extend<{
         // Ensure application is brought to front and focused.
         await macOSActivate(applicationName);
 
-        // Cancel auto navigation
+        // Cancel auto navigation.
         await voiceOverPlaywright.perform(
           { keyCode: MacOSKeyCodes.Control },
           { capture: false },
         );
+        await delay(100);
 
         // Ensure the document is ready and focused.
         await page.bringToFront();
@@ -107,31 +111,39 @@ export const voiceOverTest = test.extend<{
           voiceOverPlaywright.keyboardCommands.openItemChooser,
           { capture: false },
         );
+        await delay(100);
 
         // Filter by "web content" - currently web content items for all browsers
         // are suffixed by "web content".
-        await voiceOverPlaywright.type("web content", { capture: false });
+        for (const character of "web content") {
+          await voiceOverPlaywright.type(character, { capture: false });
+          await delay(100);
+        }
 
         // Select the web content window spot.
         await voiceOverPlaywright.perform(
           { keyCode: MacOSKeyCodes.Enter },
           { capture: false },
         );
+        await delay(100);
 
         // Navigate into web content.
         await voiceOverPlaywright.interact({ capture: false });
+        await delay(100);
 
         // Navigate to the beginning of the web content.
         await voiceOverPlaywright.perform(
           voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
           { capture: false },
         );
+        await delay(100);
 
         // Cancel auto navigation
         await voiceOverPlaywright.perform(
           { keyCode: MacOSKeyCodes.Control },
           { capture: false },
         );
+        await delay(100);
 
         // Navigate to the beginning of the web content, using chosen capture
         // settings, so don't miss announcing the first item on the page.

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -88,7 +88,7 @@ export const voiceOverTest = test.extend<{
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      voiceOverPlaywright.navigateToWebContent = async ({ capture }) => {
+      voiceOverPlaywright.navigateToWebContent = async ({ capture } = {}) => {
         // Ensure application is brought to front and focused.
         await macOSActivate(applicationName);
 

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -33,10 +33,8 @@ export interface VoiceOverPlaywright extends VoiceOver {
    * of the browser's web content.
    *
    * This command should be used after a page navigation has completed.
-   *
-   * Note: this command clears all logs by default.
    */
-  navigateToWebContent(clearLogs?: boolean): Promise<void>;
+  navigateToWebContent(options: Pick<CommandOptions, "capture">): Promise<void>;
 }
 
 const voiceOverPlaywright: VoiceOverPlaywright =
@@ -90,14 +88,15 @@ export const voiceOverTest = test.extend<{
         throw new Error(`Browser ${browserName} is not installed.`);
       }
 
-      voiceOverPlaywright.navigateToWebContent = async (
-        clearLogs: boolean = true,
-      ) => {
+      voiceOverPlaywright.navigateToWebContent = async ({ capture }) => {
         // Ensure application is brought to front and focused.
         await macOSActivate(applicationName);
 
         // Cancel auto navigation
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+        await voiceOverPlaywright.perform(
+          { keyCode: MacOSKeyCodes.Control },
+          { capture: false },
+        );
 
         // Ensure the document is ready and focused.
         await page.bringToFront();
@@ -106,31 +105,40 @@ export const voiceOverTest = test.extend<{
         // Open the web item chooser.
         await voiceOverPlaywright.perform(
           voiceOverPlaywright.keyboardCommands.openItemChooser,
+          { capture: false },
         );
 
         // Filter by "web content" - currently web content items for all browsers
         // are suffixed by "web content".
-        await voiceOverPlaywright.type("web content");
+        await voiceOverPlaywright.type("web content", { capture: false });
 
         // Select the web content window spot.
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Enter });
+        await voiceOverPlaywright.perform(
+          { keyCode: MacOSKeyCodes.Enter },
+          { capture: false },
+        );
 
         // Navigate into web content.
-        await voiceOverPlaywright.interact();
+        await voiceOverPlaywright.interact({ capture: false });
 
         // Navigate to the beginning of the web content.
         await voiceOverPlaywright.perform(
           voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
+          { capture: false },
         );
 
         // Cancel auto navigation
-        await voiceOverPlaywright.perform({ keyCode: MacOSKeyCodes.Control });
+        await voiceOverPlaywright.perform(
+          { keyCode: MacOSKeyCodes.Control },
+          { capture: false },
+        );
 
-        if (clearLogs) {
-          // Clear out logs.
-          await voiceOverPlaywright.clearItemTextLog();
-          await voiceOverPlaywright.clearSpokenPhraseLog();
-        }
+        // Navigate to the beginning of the web content, using chosen capture
+        // settings, so don't miss announcing the first item on the page.
+        await voiceOverPlaywright.perform(
+          voiceOverPlaywright.keyboardCommands.moveToBeginningOfText,
+          { capture },
+        );
       };
 
       await voiceOverPlaywright.start(voiceOverStartOptions);

--- a/src/voiceOverTest.ts
+++ b/src/voiceOverTest.ts
@@ -111,7 +111,7 @@ export const voiceOverTest = test.extend<{
           voiceOverPlaywright.keyboardCommands.openItemChooser,
           { capture: false },
         );
-        await delay(100);
+        await delay(500);
 
         // Filter by "web content" - currently web content items for all browsers
         // are suffixed by "web content".


### PR DESCRIPTION
# Issue

No issue

## Details

Currently `.navigateToWebContent()` behaves differently to other Guidepup commands.

This is a breaking change to update the interface to start taking an options argument, to align the interface and behaviour, starting with support for the `capture` flag:

- When `true` the full spoken phrase of the _final_ command to place the screen reader cursor on the first item of the web content is captured in full
- When `"initial"` the initial spoken phrase of the _final_ command to place the screen reader cursor on the first item of the web content is captured
- When `false` no spoken phrases are captured

## CheckList

- [ ] Has been tested (where required).
